### PR TITLE
Fix typo in misClassError documentation

### DIFF
--- a/man/misClassError.Rd
+++ b/man/misClassError.Rd
@@ -9,7 +9,7 @@ misClassError(actuals, predictedScores, threshold = 0.5)
 \arguments{
 \item{actuals}{The actual binary flags for the response variable. It can take a numeric vector containing values of either 1 or 0, where 1 represents the 'Good' or 'Events' while 0 represents 'Bad' or 'Non-Events'.}
 
-\item{predictedScores}{The prediction probability scores for each observation. If your classification model gives the 1/0 predcitions, convert it to a numeric vector of 1's and 0's.}
+\item{predictedScores}{The prediction probability scores for each observation. If your classification model gives the 1/0 predictions, convert it to a numeric vector of 1's and 0's.}
 
 \item{threshold}{If predicted value is above the threshold, it will be considered as an event (1), else it will be a non-event (0). Defaults to 0.5.}
 }


### PR DESCRIPTION
Corrected a typo in the misClassError documentation.