### PR TITLE
Fix typo on DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,7 @@ Description: Provides companion function for analysing the performance of
     'AUROC', 'IV', 'WOE' Calculation, 'KS Statistic' etc to aid accuracy improvement
     in binary classification models.
 License: GPL (>= 2)
-BugReports: https://github.com/selva86/InformationValue/issues License:
-    GPL (>= 2)
+BugReports: https://github.com/selva86/InformationValue/issues
 LazyData: TRUE
 LazyLoad: yes
 Depends:


### PR DESCRIPTION
See also https://cran.r-project.org/web/checks/check_results_InformationValue.html:

Version: 1.2.3
Check: DESCRIPTION meta-information
Result: NOTE
    BugReports field should be the URL of a single webpage